### PR TITLE
Update dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repo is a work in progress. The goal is to have all the mkdocs documentation files in this repo for [docs.openbazaar.org](docs.openbazaar.org). Then [docs.openbazaar.org](docs.openbazaar.org) can load files directly from master. 
 
-There is a #documentation_2-0 channel on the OpenBazaar Slack if you have any questions about this repo. You can join the OpenBazaar Slack [here](http://slack.openbazaar.org).
+There is a #documentation_2-0 channel on the OpenBazaar Slack if you have any questions about this repo. You can join the OpenBazaar Slack [here](https://openbazaar.slack.com).
 
 If you are new to OpenBazaar, the easiest way to start contributing to this documentation repo is to fork it, define some term(s) in the [Glossary](docs/glossary.md) and make a pull request. 


### PR DESCRIPTION
Update dead slack link to https://openbazaar.slack.com